### PR TITLE
Fix getCommentsByMediaCode() method

### DIFF
--- a/src/main/java/me/postaddict/instagram/scraper/request/GetCommentsByMediaCode.java
+++ b/src/main/java/me/postaddict/instagram/scraper/request/GetCommentsByMediaCode.java
@@ -36,7 +36,7 @@ public class GetCommentsByMediaCode extends PaginatedRequest<PageObject<Comment>
     @Override
     protected PageInfo getPageInfo(PageObject<Comment> current) {
         List<Comment> comments = current.getNodes();
-        return new PageInfo(current.getPageInfo().isHasNextPage(),Long.toString(comments.get(comments.size()-1).getId()));
+        return new PageInfo(current.getPageInfo().isHasNextPage(),Long.toString(comments.get(0).getId()));
     }
 
     @Override


### PR DESCRIPTION
This method returns the same first 20 comments for each request